### PR TITLE
docs: update README JEP links; ci: use JDK 25

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -60,8 +60,8 @@ jobs:
       uses: actions/setup-java@v4
       with:
         # https://github.com/actions/setup-java?tab=readme-ov-file#supported-distributions
-        java-version: '24'
-        distribution: 'zulu'
+        java-version: '25'
+        distribution: 'temurin'
 
     # Generates and submits a dependency graph, enabling Dependabot Alerts for all project dependencies.
     # See: https://github.com/gradle/actions/blob/main/dependency-submission/README.md

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -75,7 +75,7 @@ if (enablePreviewFeatures) {
         (options as StandardJavadocDocletOptions).apply {
             addStringOption("Xmaxwarns", "1")
             addBooleanOption("-enable-preview", true)
-            source = "24"
+            source = "25"
         }
     }
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -171,7 +171,7 @@ if (enablePreviewFeatures) {
     tasks.withType<Javadoc>() {
         (options as StandardJavadocDocletOptions).apply {
             addBooleanOption("-enable-preview", true)
-            source = "24"
+            source = "25"
         }
     }
 

--- a/tcp-gameserver/build.gradle.kts
+++ b/tcp-gameserver/build.gradle.kts
@@ -63,7 +63,7 @@ if (enablePreviewFeatures) {
     tasks.withType<Javadoc>() {
         (options as StandardJavadocDocletOptions).apply {
             addBooleanOption("-enable-preview", true)
-            source = "24"
+            source = "25"
         }
     }
 }


### PR DESCRIPTION
README:
Link JEP474 to ZGC examples in
app/build.gradle.kts
 and
tcp-gameserver/build.gradle.kts
.
Condense JEP471 and add examples: FFM (native/.../TicTacToeGameBoard.java, native/.../TicTacToeLibrary.java), Cleaner (native/.../TicTacToeGameBoard.java), VarHandles (api/.../PlayerIds.java). Add Related link to overengineering-tictactoe-microservices. CI:
Set up JDK 25 in
.github/workflows/gradle-publish-github.yml
 and
.github/workflows/gradle-publish-maven.yml
.